### PR TITLE
Run static middleware before any session middelware.

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -76,48 +76,7 @@ function init(callback) {
       }));
       callback();
     }],
-    beforeBodyParser: ['logger', function(callback) {
-      server.use(require('method-override')());
-      bedrock.events.emit(
-        'bedrock-express.configure.bodyParser', server, callback);
-    }],
-    bodyParser: ['beforeBodyParser', function(callback, results) {
-      if(results.beforeBodyParser === false) {
-        return callback();
-      }
-      // parse application/json, application/*+json
-      server.use(bodyParser.json({type: ['json', '+json']}));
-      // Note: Do *NOT* parse `application/x-www-form-urlencoded` by default;
-      // it makes protecting JSON-based handlers from CSRF more difficult
-      callback();
-    }],
-    beforeCookieParser: ['bodyParser', function(callback) {
-      bedrock.events.emit(
-        'bedrock-express.configure.cookieParser', server, callback);
-    }],
-    cookieParser: ['bodyParser', function(callback, results) {
-      if(results.bodyParser === false) {
-        return callback();
-      }
-      server.use(require('cookie-parser')(
-        bedrock.config.express.session.secret));
-      callback();
-    }],
-    beforeSession: ['cookieParser', function(callback) {
-      bedrock.events.emit(
-        'bedrock-express.configure.session', server, callback);
-    }],
-    session: ['beforeSession', function(callback, results) {
-      if(results.beforeSession === false) {
-        return callback();
-      }
-      if(bedrock.config.express.useSession) {
-        server.use(api.middleware['express-session'](
-          bedrock.config.express.session));
-      }
-      callback();
-    }],
-    beforeStatic: ['session', function(callback) {
+    beforeStatic: ['logger', function(callback) {
       bedrock.events.emit('bedrock-express.configure.static', server, callback);
     }],
     static: ['beforeStatic', function(callback, results) {
@@ -183,7 +142,48 @@ function init(callback) {
       });
       callback();
     }],
-    beforeRouter: ['cache', function(callback) {
+    beforeBodyParser: ['cache', function(callback) {
+      server.use(require('method-override')());
+      bedrock.events.emit(
+        'bedrock-express.configure.bodyParser', server, callback);
+    }],
+    bodyParser: ['beforeBodyParser', function(callback, results) {
+      if(results.beforeBodyParser === false) {
+        return callback();
+      }
+      // parse application/json, application/*+json
+      server.use(bodyParser.json({type: ['json', '+json']}));
+      // Note: Do *NOT* parse `application/x-www-form-urlencoded` by default;
+      // it makes protecting JSON-based handlers from CSRF more difficult
+      callback();
+    }],
+    beforeCookieParser: ['bodyParser', function(callback) {
+      bedrock.events.emit(
+        'bedrock-express.configure.cookieParser', server, callback);
+    }],
+    cookieParser: ['bodyParser', function(callback, results) {
+      if(results.bodyParser === false) {
+        return callback();
+      }
+      server.use(require('cookie-parser')(
+        bedrock.config.express.session.secret));
+      callback();
+    }],
+    beforeSession: ['cookieParser', function(callback) {
+      bedrock.events.emit(
+        'bedrock-express.configure.session', server, callback);
+    }],
+    session: ['beforeSession', function(callback, results) {
+      if(results.beforeSession === false) {
+        return callback();
+      }
+      if(bedrock.config.express.useSession) {
+        server.use(api.middleware['express-session'](
+          bedrock.config.express.session));
+      }
+      callback();
+    }],
+    beforeRouter: ['session', function(callback) {
       bedrock.events.emit('bedrock-express.configure.router', server, callback);
     }],
     router: ['beforeRouter', function(callback) {


### PR DESCRIPTION
Fixes an issue where requests on static files would invoke session middleware and cause large amounts of unneccessary calls to the database