### PR TITLE
Attach express on `bedrock.start` instead of `bedrock.ready`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,22 +42,6 @@ morgan.token('remote-addr', req => req.ip);
 // default jsonld mimetype
 express.static.mime.define({'application/ld+json': ['jsonld']});
 
-// track when bedrock is ready to attach express
-bedrock.events.on('bedrock.ready', callback => {
-  bedrock.events.emit('bedrock-express.ready', server, (err, cancel) => {
-    if(err) {
-      return callback(err);
-    }
-    if(cancel === false) {
-      // default attach canceled, return early
-      return callback();
-    }
-    // attach express to TLS
-    bedrockServer.servers.https.on('request', server);
-    callback();
-  });
-});
-
 // setup server on bedrock start
 bedrock.events.on('bedrock.start', init);
 
@@ -221,8 +205,18 @@ function init(callback) {
         callback();
       }],
     start: ['unhandledErrorHandler', callback => bedrock.events.emit(
-      'bedrock-express.start', server, callback)]
-    // Note: 'bedrock-express.ready' emitted in 'bedrock.ready' handler
+      'bedrock-express.start', server, callback)],
+    ready: ['start', callback => bedrock.events.emit(
+      'bedrock-express.ready', server, callback)],
+    attach: ['ready', (callback, results) => {
+      if(results.ready === false) {
+        // default attach canceled, return early
+        return callback();
+      }
+      // attach express to TLS
+      bedrockServer.servers.https.on('request', server);
+      callback();
+    }]
   }, err => callback(err));
 }
 


### PR DESCRIPTION
- This addresses a bug where express may not be attached before
  the server is ready.