### PR TITLE
Fix error handler signature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-express ChangeLog
 
+### Fixed
+- Error handler signature.
+
 ## 3.0.0 - 2019-11-08
 
 ### Added

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,7 +210,7 @@ function _handleJsonError() {
       case 'none': {
         // no logging
         break;
-      };
+      }
       case 'summary': {
         // name, message, and httpStatusCode
         const details = {
@@ -222,7 +222,7 @@ function _handleJsonError() {
         }
         logger.error('error', details);
         break;
-      };
+      }
       case 'full': {
         // full error
         logger.error('error', {error: err.toObject()});

--- a/lib/index.js
+++ b/lib/index.js
@@ -264,7 +264,8 @@ function _handleError() {
     });
   }
   // default error handler
-  return (err, req, res) => {
+  /* eslint-disable-next-line no-unused-vars */
+  return (err, req, res, next) => {
     // if err.status is set, respect it and the error message
     let msg = 'Internal Server Error';
     if(err.status) {


### PR DESCRIPTION
Error handler signatures are required to have 4 params.  This showed up when running in `NODE_ENV=production` mode.  Unsure why it wasn't a problem before.