### PR TITLE
Add session.ttl to config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Add `bedrock-express.fastify.ready` event when the express app is ready and
   has been added to `fastify`.
 - Expose `fastify` instance and `Fastify` class via module API.
+- A new option config.express.session.ttl used by session storage libraries.
+- Updated the Configuration section of the README with ttl options
 
 ### Changed
 - Update underlying engine to use fastify with an express compatibility layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   has been added to `fastify`.
 - Expose `fastify` instance and `Fastify` class via module API.
 - A new option config.express.session.ttl used by session storage libraries.
-- Updated the Configuration section of the README with ttl options
+- Updated the Configuration section of the README with ttl options.
 
 ### Changed
 - Update underlying engine to use fastify with an express compatibility layer.
@@ -21,6 +21,9 @@
 - **BREAKING**: Change bedrock-server peer dependency to 3.x. This is not a hard
   requirement; bedrock-server 2.x should work with this change, however, a
   new major revision avoids having to support 2.x.
+- **BREAKING** `config.express.session.saveUninitialized` now defaults to false.
+  Unmodified sessions will no longer save to the database until data has been
+  added to the session.
 
 ### Removed
 - Removed broken/obsolete/unusable multiview hack to underlying express library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add `bedrock-express.fastify.ready` event when the express app is ready and
   has been added to `fastify`.
 - Expose `fastify` instance and `Fastify` class via module API.
-- A new option config.express.session.ttl used by session storage libraries.
+- A new option, `config.express.session.ttl`, used by session storage libraries.
 - Updated the Configuration section of the README with ttl options.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ function addRoutes(app) {
 For documentation on configuration, see [config.js](./lib/config.js).
 
 `config.express.session.ttl` is a new option in version 3.3.0 that should be a number
-expressing in milliseconds how long a session should last.
+expressing in milliseconds how long a session should last. This should be
+enforced by a session store on the server as opposed to the client.
 `config.express.session.ttl` defaults to 30 minutes in milliseconds.
 This option should be used by [`express-session storage implementations`](https://www.npmjs.com/package/express-session#session-store-implementation) that can access `bedrock-express` configuration options.
 [`bedrock-session-mongodb`](https://github.com/digitalbazaar/bedrock-session-mongodb/pull/12/files) can be used as an example.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ function addRoutes(app) {
 
 For documentation on configuration, see [config.js](./lib/config.js).
 
+`config.express.session.ttl` is a new option in version 3.3.0 that should be a number
+expressing in milliseconds how long a session should last.
+`config.express.session.ttl` defaults to 30 minutes in milliseconds.
+This option should be used by [`express-session storage implementations`](https://www.npmjs.com/package/express-session#session-store-implementation) that can access `bedrock-express` configuration options.
+[`bedrock-session-mongodb`](https://github.com/digitalbazaar/bedrock-session-mongodb/pull/12/files) can be used as an example.
+
 ## How It Works
 
 **bedrock-express** exposes an express server over TLS, using the

--- a/README.md
+++ b/README.md
@@ -32,12 +32,16 @@ function addRoutes(app) {
 
 For documentation on configuration, see [config.js](./lib/config.js).
 
-`config.express.session.ttl` is a new option in version 3.3.0 that should be a number
-expressing in milliseconds how long a session should last. This should be
-enforced by a session store on the server as opposed to the client.
+`config.express.session.ttl` is was added in version 5.0.0 that should be a
+number expressing in milliseconds how long a session should last. This can
+be enforced by a session store on the server as opposed to the client.
+
 `config.express.session.ttl` defaults to 30 minutes in milliseconds.
-This option should be used by [`express-session storage implementations`](https://www.npmjs.com/package/express-session#session-store-implementation) that can access `bedrock-express` configuration options.
-[`bedrock-session-mongodb`](https://github.com/digitalbazaar/bedrock-session-mongodb/pull/12/files) can be used as an example.
+
+This option should be used by [express-session storage implementations][]
+that can access `bedrock-express` configuration options.
+[`bedrock-session-mongodb`](https://github.com/digitalbazaar/bedrock-session-mongodb/pull/12/files)
+can be used as an example.
 
 ## How It Works
 
@@ -60,13 +64,13 @@ HTTP requests arrive, they will be redirected to HTTPS. If you want to
 enable HTTP requests, do the following:
 
 ```js
-var brServer = require('bedrock-server');
-var brExpress = require('bedrock-express');
+const brServer = require('bedrock-server');
+const brExpress = require('bedrock-express');
 
 // track when bedrock is ready to attach express
 bedrock.events.on('bedrock.ready', function() {
   // attach express app to regular http
-  brServer.servers.http.on('request', brExpress.app);
+  brServer.servers.http.on('request', brExpress.requestHandler);
 });
 ```
 
@@ -80,6 +84,15 @@ first parameter to the listener function. The most commonly used event is
 `bedrock-express.configure.routes`, which allows modules to attach new routes
 to express to provide, for example, a REST API.
 
+In version 5.0.0, a [fastify][] compatibility layer was added to add in the
+transition to [fastify][], which is a better maintained and more performant
+http server framework. Some new events were added related to fastify setup.
+
+- **bedrock-express.fastify.init**
+  - Emitted once fastify(-express) is ready and provides access to the
+    `fastify` instance; before any other setup of the express server.
+- **bedrock-express.init**
+  - Emitted before any other setup of the express server.
 - **bedrock-express.init**
   - Emitted before any other setup of the express server.
 - **bedrock-express.configure.logger**
@@ -158,7 +171,10 @@ to express to provide, for example, a REST API.
 - **bedrock-express.ready**
   - Emitted after `bedrock-express.start`, indicating that all listeners
     should have already completed any special custom behavior on start up.
-
+- **bedrock-express.fastify.ready**
+  - Emitted after `bedrock-express.ready` once the express app that was
+    assembled via all the previous events has been added to `fastify` so
+    that it can be served on `bedrock-server.ready`.
 
 [bedrock]: https://github.com/digitalbazaar/bedrock
 [bedrock-server]: https://github.com/digitalbazaar/bedrock-server
@@ -166,3 +182,5 @@ to express to provide, for example, a REST API.
 [express]: https://github.com/strongloop/express
 [morgan]: https://github.com/expressjs/morgan
 [express-session]: https://github.com/expressjs/session
+[express-session storage implementations]: https://www.npmjs.com/package/express-session#session-store-implementation
+[fastify]: https://github.com/fastify/fastify

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,5 @@
-/*
- * Bedrock Express Module Configuration
- *
- * Copyright (c) 2012-2020 Digital Bazaar, Inc. All rights reserved.
+/*!
+ * Copyright (c) 2012-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -23,14 +21,15 @@ config.express.session.resave = true;
 config.express.session.saveUninitialized = false;
 config.express.session.cookie = {};
 config.express.session.cookie.secure = true;
-// NOTE: Setting `maxAge` to `null` will instruct the browser to avoid deleting it -- leaving
-// all session management up to the server and the Web application it serves. If it is
-// not set to `null`, then either the cookie will always be removed after some fixed
-// period of time even when the user is active -- otherwise, the `Set-Cookie` header
-// will have to be sent on every request in order to advance `maxAge` to keep sessions
-// open due to activity which creates significant overhead and more session
-// management and synchronization complexity (between the server's session TTL and
-// the client's cookie) that is usually not worth the cost.
+/* Note: Setting `maxAge` to `null` will instruct the browser to avoid
+deleting it -- leaving all session management up to the server and the Web
+application it serves. If it is not set to `null`, then either the cookie will
+always be removed after some fixed period of time even when the user is active;
+otherwise, the `Set-Cookie` header will have to be sent on every request in
+order to advance `maxAge` to keep sessions open due to activity which creates
+significant overhead and more session management and synchronization complexity
+(between the server's session TTL and the client's cookie) that is usually not
+worth the cost. */
 config.express.session.cookie.maxAge = null;
 // ttl is set in milliseconds
 // express-session storage implementations such as MongoStore should use this.

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,8 @@ config.express.session.secret = '0123456789abcdef';
 config.express.session.key = 'bedrock.sid';
 config.express.session.prefix = 'bedrock.';
 config.express.session.resave = true;
+// sessions that have not been modified are not saved to the db
+// until modified.
 config.express.session.saveUninitialized = false;
 config.express.session.cookie = {};
 config.express.session.cookie.secure = true;

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,7 +18,7 @@ config.express.session.secret = '0123456789abcdef';
 config.express.session.key = 'bedrock.sid';
 config.express.session.prefix = 'bedrock.';
 config.express.session.resave = true;
-config.express.session.saveUninitialized = true;
+config.express.session.saveUninitialized = false;
 config.express.session.cookie = {};
 config.express.session.cookie.secure = true;
 // NOTE: setting maxAge will allow cookies to persist

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,12 +21,13 @@ config.express.session.resave = true;
 config.express.session.saveUninitialized = true;
 config.express.session.cookie = {};
 config.express.session.cookie.secure = true;
-// NOTE: 'connect' doesn't update the expires age for the cookie on every
-//   request so sessions will always timeout on the client after the maxAge
-//   time. Setting to null will cause sessions checks to only happen on the
-//   server which does update the expires time on every request. The server
-//   session defaultExpirationTime is set below.
+// NOTE: setting maxAge will allow cookies to persist
+// after the ttl has expired
 config.express.session.cookie.maxAge = null;
+// ttl is set in milliseconds
+// session stores such as MongoStore should use this.
+// ttl default time is 30 minutes
+config.express.session.ttl = 30 * 60 * 1000;
 
 // server cache
 config.express.cache = {};

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,7 +25,7 @@ config.express.session.cookie.secure = true;
 // after the ttl has expired
 config.express.session.cookie.maxAge = null;
 // ttl is set in milliseconds
-// session stores such as MongoStore should use this.
+// express-session storage implementations such as MongoStore should use this.
 // ttl default time is 30 minutes
 config.express.session.ttl = 30 * 60 * 1000;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,8 +23,14 @@ config.express.session.resave = true;
 config.express.session.saveUninitialized = false;
 config.express.session.cookie = {};
 config.express.session.cookie.secure = true;
-// NOTE: setting maxAge will allow cookies to persist
-// after the ttl has expired
+// NOTE: Setting `maxAge` to `null` will instruct the browser to avoid deleting it -- leaving
+// all session management up to the server and the Web application it serves. If it is
+// not set to `null`, then either the cookie will always be removed after some fixed
+// period of time even when the user is active -- otherwise, the `Set-Cookie` header
+// will have to be sent on every request in order to advance `maxAge` to keep sessions
+// open due to activity which creates significant overhead and more session
+// management and synchronization complexity (between the server's session TTL and
+// the client's cookie) that is usually not worth the cost.
 config.express.session.cookie.maxAge = null;
 // ttl is set in milliseconds
 // express-session storage implementations such as MongoStore should use this.

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,8 @@ bedrock.events.on('bedrock.start', async () => {
   // set `_fastify` as underlying implementation for `fastify` proxy
   _fastify = Fastify({
     serverFactory(requestHandler) {
+      // expose request handler
+      api.requestHandler = requestHandler;
       server.listen = (options, callback) => {
         // we are already listening so just attach the fastify request handler
         server.on('request', requestHandler);
@@ -244,6 +246,7 @@ bedrock.events.on('bedrock.start', async () => {
   }
   // start
   await bedrock.events.emit('bedrock-express.start', app);
+
   // ready check
   let canceled = await bedrock.events.emit(
     'bedrock-express.ready', app) === false;
@@ -255,7 +258,7 @@ bedrock.events.on('bedrock.start', async () => {
   // add express app to fastify
   fastify.use(app);
 
-  // do not attach if ready was canceled
+  // fastify ready check
   canceled = await bedrock.events.emit(
     'bedrock-express.fastify.ready', app) === false;
   // do not attach if ready was canceled


### PR DESCRIPTION
Adds a time to live option for sessions in milliseconds.
Defaults to 30 minutes.