### PR TITLE
Bump peer deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-express ChangeLog
 
+## 3.2.1 - TBD
+
+### Changed
+- Changed peerDependency for `bedrock` to allow `4.x`.
+
 ## 3.2.0 - 2020-06-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "morgan": "^1.9.1"
   },
   "peerDependencies": {
-    "bedrock": "1.17.0 - 3.x",
+    "bedrock": "1.17.0 - 4.x",
     "bedrock-server": "^2.0.0"
   },
   "directories": {


### PR DESCRIPTION
Bumps the peerDependency for `bedrock` to allow `4.x.`