### PR TITLE
Set default value for `dumpExceptions` to `false`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-express ChangeLog
 
+## 6.0.0 - TBD
+
+### Changed
+- **BREAKING**: Set default value for `dumpExceptions` to `false`. This prevents
+  unwanted stack traces from being included with HTML error responses.
+
 ## 5.0.1 - 2021-08-25
 
 ### Fixed

--- a/lib/config.js
+++ b/lib/config.js
@@ -50,8 +50,11 @@ config.express.staticOptions = {
 config.express.useSession = false;
 
 // errors
-// true for full error output (HTML, etc)
-config.express.dumpExceptions = true;
+// `true` for full error output (HTML, etc)
+// NOTE: `true` should only be used for *local* development purposes only, this
+// setting causes stack traces to be included with all errors including
+// NotAllowedError which is not appropriate for any public facing deployment
+config.express.dumpExceptions = false;
 
 // verbosity of JSON error logging
 //   'none': no logging


### PR DESCRIPTION
This reverses a change that was made in v4: https://github.com/digitalbazaar/bedrock-express/blob/main/CHANGELOG.md#400---2021-04-21

It has been suggested that using `ensureConfigOverride.enable` would be helpful to ensure that this is set properly in public deployments.  In practical application this flag is used to transition from the CI/CD pipeline (QA, Staging) into production setting.  Therefore `ensureConfigOverride` is not useful for ensuring that `dumpExceptions` is `false` for *any* public deployment.  For that, Digital Bazaar will be explicitly setting this to `false` in all root application configs [EDIT] for public deployments.  This however will not prevent third parties from publishing applications with the less secure `true` setting.

