### PR TITLE
Only set PNA header on preflict request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-express ChangeLog
 
+## 6.2.2 - 2022-xx-xx
+
+### Fixed
+- Only set Private Network Access header on preflight request.
+
 ## 6.2.1 - 2022-01-16
 
 ### Fixed

--- a/lib/index.js
+++ b/lib/index.js
@@ -587,6 +587,8 @@ function asyncHandler(middleware) {
 // to continue but does not allow the new security feature to be turned on
 // when running on localhost (though this may be an uncommon use case)
 function _allowLocalhostCors(req, res, next) {
-  res.setHeader('Access-Control-Allow-Private-Network', 'true');
+  if(req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Private-Network', 'true');
+  }
   next();
 }


### PR DESCRIPTION
- Based on text in the example at
  https://wicg.github.io/private-network-access/#shortlinks.  The header
  may only be needed for preflight OPTIONS requests.

Unsure if this is correct.  Untested as I don't yet have the browser and server setup that uses this new check.