### PR TITLE
Add strict: false to bodyParser options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-express ChangeLog
 
+## 8.1.0 -
+
+### Changed
+- Allow json `req.body`s that are not Arrays or Objects.
+
 ## 8.0.0 - 2022-04-28
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -238,7 +238,7 @@ bedrock.events.on('bedrock.start', async () => {
     await bedrock.events.emit('bedrock-express.configure.bodyParser', app);
   if(configBodyParser !== false) {
     // parse application/json, application/*+json
-    app.use(bodyParser.json({type: ['json', '+json']}));
+    app.use(bodyParser.json({strict: false, type: ['json', '+json']}));
     // Note: Do *NOT* parse `application/x-www-form-urlencoded` by default;
     // it makes protecting JSON-based handlers from CSRF more difficult
   }


### PR DESCRIPTION
`strict: false` is not set for json parser.