### PR TITLE
Update `fastify` and `@fastify/express` to address vulnerability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-express ChangeLog
 
+## 8.2.0 - 2023-01-xx
+
+### Changed
+- Update `fastify` and `@fastify/express` to latest version to address
+  [CVE-2022-39288](https://nvd.nist.gov/vuln/detail/CVE-2022-39288).
+
 ## 8.1.0 - 2022-10-10
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-express",
   "dependencies": {
-    "@fastify/express": "^1.0.0",
+    "@fastify/express": "^2.3.0",
     "body-parser": "^1.20.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",
@@ -34,7 +34,7 @@
     "errorhandler": "^1.5.1",
     "express": "^4.18.0",
     "express-session": "^1.17.2",
-    "fastify": "^3.29.0",
+    "fastify": "^4.11.0",
     "method-override": "^3.0.0",
     "morgan": "^1.10.0"
   },


### PR DESCRIPTION
Upgrades to latest fastify versions to address [CVE-2022-39288](https://nvd.nist.gov/vuln/detail/CVE-2022-39288).

May resolve #52 