### PR TITLE
Update cors setup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-express ChangeLog
 
+## 8.2.1 - 2024-xx-xx
+
+### Fixed
+- Format cors correctly when using boolean from bedrock config system.
+
 ## 8.2.0 - 2023-03-23
 
 ### Changed

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,9 +178,9 @@ bedrock.events.on('bedrock.start', async () => {
       // setup cors
       let corsHandler = null;
       if('cors' in cfg) {
-        if(typeof cfg.cors === 'boolean' && cfg.cors) {
-          // if boolean and true just use defaults
-          corsHandler = cors();
+        if(typeof cfg.cors === 'boolean') {
+          // if boolean format and pass through
+          corsHandler = cors({origin: cfg.cors});
         } else {
           // if object, use as cors config
           corsHandler = cors(cfg.cors);


### PR DESCRIPTION
Makes it so that when the cors value from the bedrock config system is set as a boolean, that boolean is used as the `origin` in a `corsOptions` object.

In the previous logic, there appears to be a bug(?) when setting `cfg.cors` to `false`. When `false`, the `else` block will always be executed.
```js
if('cors' in cfg) {
  if(typeof cfg.cors === 'boolean' && cfg.cors) {
    // if boolean and true just use defaults
    corsHandler = cors();
  } else {
    // if object, use as cors config
    corsHandler = cors(cfg.cors);
  }
}
```

Looking at the [cors](https://github.com/expressjs/cors) package, `options` is merged on top of `defaults` (unless `options` is a function). So when `cfg.cors` is `false`, we end up with the [default behavior](https://runjs.co/s/xU2LYOElG) where cors is enabled. In practice, this means the only way to disable cors is to remove the config setting entirely. This feels counterintuitive, since it can be reasonably assumed that setting `cfg.cors = false` would result in cors being disabled rather than enabled. 

```js
// https://github.com/expressjs/cors/blob/master/lib/index.js#L8-L13
var defaults = {
   origin: '*',
   methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
   preflightContinue: false,
   optionsSuccessStatus: 204
 };
// https://github.com/expressjs/cors/blob/master/lib/index.js#L208
var corsOptions = assign({}, defaults, options);
// https://github.com/expressjs/cors/blob/master/lib/index.js#L224
cors(corsOptions, req, res, next);
```

https://github.com/expressjs/cors#configuration-options