### PR TITLE
Replace `@fastify/express` with in-repo adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ package-lock.json
 .claude
 .entire
 .fastembed_cache
-SLACK.md

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ npm-debug.log
 reports
 .nyc_output
 package-lock.json
+
+# local tooling / agent artifacts
+.claude
+.entire
+.fastembed_cache
+SLACK.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # bedrock-express ChangeLog
 
+## 8.7.0 - 2026-xx-xx
+
+### Removed
+- **BREAKING (undocumented API):** Removed the undocumented `fastify.use`
+  method. Its only purpose was internally mounting the express `app`; this is
+  now handled directly by the new express adapter. Modules should continue to
+  use the documented `bedrock-express.configure.*` event API.
+- Removed the `@fastify/express` dependency. The small amount of behavior
+  needed to run express inside fastify is now provided by an in-repo adapter
+  (`lib/express-adapter.js`).
+
+### Changed
+- Replaced `@fastify/express` and the reactive monkeypatching around it with a
+  minimal in-repo express adapter. The request URL is no longer decoded or
+  normalized before express routing (encoding is not a security boundary and
+  decoding corrupts encoded path parameters), and `headersSent` is no longer
+  added to the raw response until `send()` is called (its mere presence can
+  abort callers of the http2 `writeHead`). External behavior is otherwise
+  unchanged.
+
 ## 8.6.7 - 2026-05-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 8.7.0 - 2026-xx-xx
 
+### Added
+- Preserve backwards compatibility for `fastify.express`. `@fastify/express`
+  used to decorate the fastify instance with an `express` property; the fastify
+  instance is now decorated with the root express `app` so external consumers
+  that read `fastify.express` continue to work.
+
 ### Removed
 - **BREAKING (undocumented API):** Removed the undocumented `fastify.use`
   method. Its only purpose was internally mounting the express `app`; this is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-express ChangeLog
 
-## 8.7.0 - 2026-xx-xx
+## 8.6.8 - 2026-xx-xx
 
 ### Added
 - Preserve backwards compatibility for `fastify.express`. `@fastify/express`
@@ -8,23 +8,22 @@
   instance is now decorated with the root express `app` so external consumers
   that read `fastify.express` continue to work.
 
-### Removed
-- **BREAKING (undocumented API):** Removed the undocumented `fastify.use`
-  method. Its only purpose was internally mounting the express `app`; this is
-  now handled directly by the new express adapter. Modules should continue to
-  use the documented `bedrock-express.configure.*` event API.
-- Removed the `@fastify/express` dependency. The small amount of behavior
-  needed to run express inside fastify is now provided by an in-repo adapter
-  (`lib/express-adapter.js`).
-
 ### Changed
 - Replaced `@fastify/express` and the reactive monkeypatching around it with a
-  minimal in-repo express adapter. The request URL is no longer decoded or
+  minimal internal express adapter. The request URL is no longer decoded or
   normalized before express routing (encoding is not a security boundary and
   decoding corrupts encoded path parameters), and `headersSent` is no longer
   added to the raw response until `send()` is called (its mere presence can
   abort callers of the http2 `writeHead`). External behavior is otherwise
   unchanged.
+
+### Removed
+- **BREAKING (undocumented API):** Removed the undocumented `fastify.use`
+  method. Its only purpose was internally mounting the express `app`; this is
+  now handled directly by the new, internal express adapter. Modules should
+  continue to use the documented `bedrock-express.configure.*` event API.
+- Removed the `@fastify/express` dependency. The small amount of behavior
+  needed to run express inside fastify is now provided by an internal adapter.
 
 ## 8.6.7 - 2026-05-29
 

--- a/docs/specs/fastify-express-adapter.md
+++ b/docs/specs/fastify-express-adapter.md
@@ -1,0 +1,172 @@
+# Tech Spec: Replace `@fastify/express` with an in-repo adapter
+- **Author:** DJ Scruggs
+  
+- **Date:** 2026-06-02
+  
+- **Status:** Draft — for Engineering / DevOps / CTO / Privacy Officer review
+  
+- **Repo:** `@digitalbazaar/bedrock-express`
+  
+  
+## 1. Problem
+`@fastify/express` is a ~186-line connect-style adapter that runs our Express app as a fallback handler inside Fastify. It introduced two behaviors that fight Bedrock, forcing us to monkeypatch their monkeypatches:
+
+1. **Eager URL decoding.** In `enhanceRequest`, upstream runs `decodeURI(url)` + `normalizeUrl(...)` and hands the _decoded_ URL to Express. This was a reaction to a reported "bypass" (URL-encoding a path to slip past a route guard). Encoding is not a security boundary; decoding the path eagerly corrupts encoded path parameters (a `%2F` inside a segment becomes a real `/`). We undo it by restoring `req.raw.url` from `originalUrl` (`lib/index.js:184`, `:208`).
+  
+2. **Unconditional** `headersSent` **property.** Upstream always runs `Object.defineProperty(reply.raw, 'headersSent', ...)`. The _mere presence_ of this property on `reply.raw` — even when `false`/`undefined` — derails any code that calls `Http2ServerResponse.writeHead` (Node http2 compat layer; webpack hot middleware). We delete the property when not truthy and re-implement `send`/`headersSent` to define it lazily (`lib/index.js:189-210`).
+  
+
+**Cost asymmetry.** Upstream is ~186 lines; our reactive hacks are ~65 lines (`lib/index.js:150-216`) and are inherently fragile: we capture their hooks via a fake `expressHook: 'captureHook'` name, intercept `addHook` and `decorate`, replay hooks conditionally, and re-implement `send`. Every upstream change forces a counter-patch. Team consensus: fork the needed behavior into a small, owned file.
+
+**Usage scope.** `@fastify/express` is used only in `bedrock-express` (confirmed in thread). Removing it is contained to this repo.
+## 2. Goals / Non-goals
+**Goals**
+
+- Remove the `@fastify/express` dependency.
+  
+- Remove the ~65 lines of counter-patching in `lib/index.js`.
+  
+- Own a single small adapter (`lib/express-adapter.js`, ~120 lines). {>>Renamed from `fastify-express.js` per c1 — generic name avoids implying we still depend on `@fastify/express`. The file adapts Express middleware to run inside Fastify.<<}{id="c1" by="user" at="2026-06-02T14:23:12.635Z"}{#c2 re="c1"}
+  
+- Preserve current external behavior of `bedrock-express` (events, config, middleware API, http2 support).
+  
+
+**Non-goals**
+
+- No change to the Bedrock event API (`bedrock-express.configure.*`, `*.init`, `*.ready`, etc.).
+  
+- No change to `config.express.*`.
+  
+- No migration of Express middleware to native Fastify.
+  
+- No HTTP/2 redesign — existing `_addHttp2Support` / `expressHttp2` logic stays; it is ours, not upstream's.
+  
+## 3. Design
+`bedrock-express` already builds one root Express `app` (`lib/index.js:54`) and wires all middleware onto it the normal Express way (`app.use(...)` for morgan, static, cors, body-parser, session, routes, error handlers). The only thing missing is a way to run that `app` inside Fastify's request lifecycle, because Fastify owns the server and listening (via `serverFactory`).
+
+So the adapter has exactly one responsibility: **mount the existing Express** `app` **as the handler for any request that no Fastify route claimed.** It does not collect middleware, decorate `fastify.use`, or expose any registry — those were artifacts of `@fastify/express`, not things Bedrock needs.
+
+New file `lib/express-adapter.js` exposing one helper:
+
+```js
+register(fastify, {expressApp})
+```
+
+`register` adds two Fastify hooks and nothing else. {>>c2: reframed — no `fastify.use`, no middleware accumulation, no encapsulation. The adapter just mounts the existing root `app`. The single internal caller (`lib/index.js:375 fastify.use(app)`) is replaced by the adapter mounting `expressApp` directly.<<}{id="c2" by="user" at="2026-06-02T14:38:53.324Z"}{#c3 re="c2"}
+### 3.1 `onRequest` hook — make `req.raw`/`reply.raw` Express-compatible
+For each request, augment the raw Node req/res so Express middleware works, **without mangling the URL**:
+
+- set `req.raw.originalUrl = req.raw.url` (leave `url` untouched — no `decodeURI`, no normalize) **(decided: pass URL through untouched)**
+  
+- set `req.raw.id`, `hostname`, `ip`, `ips`, `log`; `reply.raw.log`
+  
+- define `req.raw.protocol` getter delegating to `req.protocol`
+  
+- copy `req.body` → `req.raw.body` (body-parser compat) when present
+  
+- copy `req.cookies` → `req.raw.cookies` (cookie-parser compat) when present
+  
+- wrap `reply.raw.send` only to guard against double-send (no URL restore needed because we never decoded it)
+  
+- **never** define `headersSent` on `reply.raw`
+  
+### 3.2 `onRequest` hook — run the Express `app` as the fallback
+When no Fastify route matched (`req.routeOptions.url === undefined`, the existing gate), copy any headers Fastify has set onto `reply.raw`, then invoke the Express app: `expressApp(req.raw, reply.raw, next)`. Otherwise call `next()` and let Fastify handle the route.
+
+This single root app handles everything; there is no per-instance/encapsulated app (decided: single root app only).
+### 3.3 What we deliberately drop from the old approach
+For reviewers familiar with `@fastify/express`, the behaviors we are **not** carrying over and why:
+
+- `decodeURI(url)` + `normalizeUrl(url)` — corrupts encoded path params; encoding is not a security boundary. **Dropped.**
+  
+- always `defineProperty(reply.raw, 'headersSent')` — its mere presence aborts http2 `writeHead` callers. **Dropped.**
+  
+- `fastify.use` decoration + `kMiddlewares` registry + `onRegister` per-instance express — unnecessary indirection; we mount the one root app directly. **Dropped.**
+  
+
+What we keep (because Express middleware genuinely needs it): `originalUrl`, `id`, `hostname`, `ip`, `ips`, `log`, `protocol`, `body`/`cookies` copy, the double-send guard, and copying Fastify-set headers before invoking the app.
+## 4. Changes to `lib/index.js`
+**Remove** (~65 lines):
+
+- `addHook` interception + `capturedHooks` (`:150-161`)
+  
+- `decorate` interception forcing local express (`:163-171`)
+  
+- `await fastify.register(fastifyExpress, {expressHook: 'captureHook'})` (`:172`)
+  
+- captured-hook replay loop incl. URL restore + `headersSent` dance (`:176-216`)
+  
+- `import fastifyExpress from '@fastify/express'` (`:27`)
+  
+- `fastify.use(app)` mount (`:375`) — the adapter mounts `app` itself now
+  
+
+**Replace with:**
+
+```js
+import {register as registerExpressAdapter} from './express-adapter.js';
+// ...
+// mounts `app` as the fallback handler; replaces both the
+// `@fastify/express` register call and the later `fastify.use(app)`
+await registerExpressAdapter(fastify, {expressApp: app});
+```
+
+`fastify.use` is no longer exposed. Its only caller was the internal `fastify.use(app)` mount; downstream modules use the documented event API, not `fastify.use`. Removal is noted in the CHANGELOG (see §5).
+
+**Keep unchanged:**
+
+- `expressHttp2` onRequest hook (`:112-148`) — our http2 augmentation
+  
+- `_addHttp2Support`, `_customExpressInit`, `_createAppWrapper` — ours
+  
+- everything from `bedrock-express.fastify.init` onward
+  
+## 5. Dependency / packaging changes
+- `package.json`: remove `@fastify/express` from `dependencies`.
+  
+- Keep `fastify` and `express` direct deps.
+  
+- Bump version per DB release flow (minor or patch — TBD with reviewer; behavior is intended to be unchanged so patch may be appropriate).
+  
+- `CHANGELOG.md`: note removal of `@fastify/express`, removal of the undocumented `fastify.use` method, and that the URL-decode fix and `headersSent` fix collapse into the in-repo adapter.
+  
+## 6. Test plan (Red/Green, `test/`)
+Write failing tests first, then implement.
+
+1. **Encoded path parameter** (the core regression): route `/foo/:id`, request `/foo/a%2Fb` → `req.params.id === 'a/b'` and `req.url` remains encoded. RED against any adapter that decodes.
+  
+2. **Double-encoding** — confirm no decode-based "bypass" is reintroduced; the app sees exactly what the client sent.
+  
+3. **http2 +** `writeHead` — a handler path that triggers `writeHead` must not abort (the `headersSent` presence regression).
+  
+4. **Double-**`send` **guard** — calling `res.send()` twice is a no-op, no throw.
+  
+5. **Express middleware compat** — body-parser (`req.body`), cookie-parser (`req.cookies`), and `protocol`/`ip` are populated on `req.raw`.
+  
+6. **Fallback gating** — a defined Fastify route takes precedence; Express only runs when `req.routeOptions.url === undefined`.
+  
+7. Existing `test/test.js` suite stays green.
+  
+
+CI runs lint (Node 22) + tests (matrix 22/24/26). Tests require nvm Node, so they are run locally with `npm test` before PR.
+## 7. Security & privacy review
+- **Attack surface:** _reduced._ We drop a transitive monkeypatch chain and own ~120 reviewable lines. No new network surface, no new data handling.
+  
+- **The "bypass" concern:** Not reintroduced. Passing the URL through unchanged means route guards see exactly what the client sent; encoding is not treated as a security boundary (correct). Route authorization remains the responsibility of downstream guards, unchanged from today's _effective_ behavior (we already restore the original URL).
+  
+- **Personal data:** none collected, stored, or transmitted by this change. `ip` / `hostname` are already surfaced on `req` by Express/Fastify today; behavior is unchanged.
+  
+- **Error handling:** no change to error responses or logging; no stack traces added to responses.
+  
+- **Misuse:** the adapter only runs the configured Express app as a fallback; no new externally controllable behavior.
+  
+## 8. Rollback
+Pure code change, no data migration. Rollback = revert the commit and restore the `@fastify/express` dependency. Pin restored to the last-known-good version if needed.
+## 9. Open questions
+1. **Version bump:** patch (behavior intended unchanged) or minor (dependency removed)? Need reviewer call.
+  
+2. `normalizeUrl` **parity:** upstream optionally collapses duplicate slashes / handles a semicolon delimiter. Decided to pass URL through untouched — do any Bedrock apps rely on duplicate-slash collapsing today? If yes, we add a minimal opt-in.
+  
+3. `createProxyHandler` **option:** upstream supports a custom Proxy handler on `req.raw`. Is any downstream module using it via `@fastify/express` directly? (Assumed no, since only `bedrock-express` consumes the dep.)
+  
+4. **HTTP/2 fallback path:** confirm the new adapter's connect-runner composes correctly with the existing `expressHttp2` hook ordering (adapter hook must run after `expressHttp2`).

--- a/docs/specs/fastify-express-adapter.md
+++ b/docs/specs/fastify-express-adapter.md
@@ -26,7 +26,7 @@
   
 - Remove the ~65 lines of counter-patching in `lib/index.js`.
   
-- Own a single small adapter (`lib/express-adapter.js`, ~120 lines). {>>Renamed from `fastify-express.js` per c1 — generic name avoids implying we still depend on `@fastify/express`. The file adapts Express middleware to run inside Fastify.<<}{id="c1" by="user" at="2026-06-02T14:23:12.635Z"}{#c2 re="c1"}
+- Own a single small adapter (`lib/expressAdapter.js`, ~120 lines). {>>Renamed from `fastify-express.js` per c1 — generic name avoids implying we still depend on `@fastify/express`. The file adapts Express middleware to run inside Fastify.<<}{id="c1" by="user" at="2026-06-02T14:23:12.635Z"}{#c2 re="c1"}
   
 - Preserve current external behavior of `bedrock-express` (events, config, middleware API, http2 support).
   
@@ -46,7 +46,7 @@
 
 So the adapter has exactly one responsibility: **mount the existing Express** `app` **as the handler for any request that no Fastify route claimed.** It does not collect middleware, decorate `fastify.use`, or expose any registry — those were artifacts of `@fastify/express`, not things Bedrock needs.
 
-New file `lib/express-adapter.js` exposing one helper:
+New file `lib/expressAdapter.js` exposing one helper:
 
 ```js
 register(fastify, {expressApp})
@@ -104,7 +104,7 @@ What we keep (because Express middleware genuinely needs it): `originalUrl`, `id
 **Replace with:**
 
 ```js
-import {register as registerExpressAdapter} from './express-adapter.js';
+import {register as registerExpressAdapter} from './expressAdapter.js';
 // ...
 // mounts `app` as the fallback handler; replaces both the
 // `@fastify/express` register call and the later `fastify.use(app)`

--- a/lib/express-adapter.js
+++ b/lib/express-adapter.js
@@ -39,7 +39,7 @@ export function register(fastify, {expressApp} = {}) {
     throw new TypeError('"expressApp" must be an Express application.');
   }
   fastify.addHook('onRequest', enhanceRequest);
-  fastify.addHook('onRequest', _createFallbackRunner(expressApp));
+  fastify.addHook('onRequest', createFallbackRunner(expressApp));
 }
 
 /**
@@ -104,9 +104,15 @@ export function enhanceRequest(req, reply, next) {
   next();
 }
 
-/* Creates the Fastify `onRequest` hook that runs the Express app as a fallback
-when no Fastify route matched the request. */
-function _createFallbackRunner(expressApp) {
+/**
+ * Creates the Fastify `onRequest` hook that runs the Express app as a fallback
+ * when no Fastify route matched the request.
+ *
+ * @param {Function} expressApp - The Express application to invoke.
+ *
+ * @returns {Function} The `onRequest` hook.
+ */
+export function createFallbackRunner(expressApp) {
   return function runExpressFallback(req, reply, next) {
     // only run Express when no Fastify route has been defined to handle the
     // request; otherwise let Fastify handle it

--- a/lib/express-adapter.js
+++ b/lib/express-adapter.js
@@ -1,0 +1,123 @@
+/*!
+ * Copyright 2026 Digital Bazaar, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This is a minimal adapter for running an Express application inside Fastify
+as the fallback handler for any request that no Fastify route claims. It
+replaces `@fastify/express`, which is no longer used. It intentionally does
+*not* decode or normalize the request URL (encoding is not a security boundary
+and decoding corrupts encoded path parameters) and does *not* add a
+`headersSent` property to the raw response until `send()` is called (the mere
+presence of that property aborts callers of the http2 `writeHead`). */
+
+/**
+ * Registers the Express adapter on a Fastify instance. Adds the request
+ * compatibility hook and the fallback runner that invokes the Express app
+ * when no Fastify route matches.
+ *
+ * @param {object} fastify - The Fastify instance.
+ * @param {object} options - The options to use.
+ * @param {Function} options.expressApp - The Express application to run as the
+ *   fallback handler.
+ */
+export function register(fastify, {expressApp} = {}) {
+  if(typeof expressApp !== 'function') {
+    throw new TypeError('"expressApp" must be an Express application.');
+  }
+  fastify.addHook('onRequest', enhanceRequest);
+  fastify.addHook('onRequest', _createFallbackRunner(expressApp));
+}
+
+/**
+ * Fastify `onRequest` hook that augments the raw Node request/response so that
+ * Express middleware works, without mangling the URL or eagerly defining
+ * `headersSent`.
+ *
+ * @param {object} req - The Fastify request.
+ * @param {object} reply - The Fastify reply.
+ * @param {Function} next - The callback to continue request handling.
+ */
+export function enhanceRequest(req, reply, next) {
+  const {raw} = req;
+
+  // leave `raw.url` exactly as received (no `decodeURI`, no normalize) so that
+  // encoded path parameters survive; expose `originalUrl` for parity with
+  // Express conventions
+  raw.originalUrl = raw.url;
+  raw.id = req.id;
+  raw.hostname = req.hostname;
+  raw.ip = req.ip;
+  raw.ips = req.ips;
+  raw.log = req.log;
+  reply.raw.log = req.log;
+
+  // `protocol` delegates to the Fastify-parsed value
+  Object.defineProperty(raw, 'protocol', {
+    get() {
+      return req.protocol;
+    },
+    configurable: true,
+    enumerable: true
+  });
+
+  // backward compatibility for body-parser
+  if(req.body) {
+    raw.body = req.body;
+  }
+  // backward compatibility for cookie-parser
+  if(req.cookies) {
+    raw.cookies = req.cookies;
+  }
+
+  // guard against a double `send()`; define `headersSent` *only* once `send()`
+  // has been called, never before
+  let replySent = false;
+  reply.raw.send = function send(...args) {
+    if(replySent) {
+      return;
+    }
+    replySent = true;
+    Object.defineProperty(reply.raw, 'headersSent', {
+      get() {
+        return replySent;
+      },
+      configurable: true,
+      enumerable: true
+    });
+    return reply.send.apply(reply, args);
+  };
+
+  next();
+}
+
+/* Creates the Fastify `onRequest` hook that runs the Express app as a fallback
+when no Fastify route matched the request. */
+function _createFallbackRunner(expressApp) {
+  return function runExpressFallback(req, reply, next) {
+    // only run Express when no Fastify route has been defined to handle the
+    // request; otherwise let Fastify handle it
+    if(req.routeOptions.url !== undefined) {
+      return next();
+    }
+    // copy any headers Fastify has already set onto the raw response so the
+    // Express app emits them
+    for(const [name, value] of Object.entries(reply.getHeaders())) {
+      reply.raw.setHeader(name, value);
+    }
+    expressApp(req.raw, reply.raw, next);
+  };
+}

--- a/lib/expressAdapter.js
+++ b/lib/expressAdapter.js
@@ -38,8 +38,12 @@ export function register(fastify, {expressApp} = {}) {
   if(typeof expressApp !== 'function') {
     throw new TypeError('"expressApp" must be an Express application.');
   }
-  fastify.addHook('onRequest', enhanceRequest);
-  fastify.addHook('onRequest', createFallbackRunner(expressApp));
+  // backwards compatibility: `@fastify/express` decorated the fastify instance
+  // with an `express` property (the express app); expose `expressApp` here so
+  // external consumers that read `fastify.express` keep working
+  fastify.decorate('express', expressApp);
+  fastify.addHook('onRequest', expressifyRequest);
+  fastify.addHook('onRequest', _createFallbackRunner(expressApp));
 }
 
 /**
@@ -51,7 +55,7 @@ export function register(fastify, {expressApp} = {}) {
  * @param {object} reply - The Fastify reply.
  * @param {Function} next - The callback to continue request handling.
  */
-export function enhanceRequest(req, reply, next) {
+export function expressifyRequest(req, reply, next) {
   const {raw} = req;
 
   // leave `raw.url` exactly as received (no `decodeURI`, no normalize) so that
@@ -84,7 +88,11 @@ export function enhanceRequest(req, reply, next) {
   }
 
   // guard against a double `send()`; define `headersSent` *only* once `send()`
-  // has been called, never before
+  // has been called, never before.
+  // TODO: this silent no-op on a second `send()` is carried over from
+  // `@fastify/express`; express itself lets a double send throw. Revisit
+  // whether to surface the error instead. See
+  // https://github.com/digitalbazaar/bedrock-express/issues/81
   let replySent = false;
   reply.raw.send = function send(...args) {
     if(replySent) {
@@ -106,13 +114,14 @@ export function enhanceRequest(req, reply, next) {
 
 /**
  * Creates the Fastify `onRequest` hook that runs the Express app as a fallback
- * when no Fastify route matched the request.
+ * when no Fastify route matched the request. Internal helper; exported only for
+ * testing.
  *
  * @param {Function} expressApp - The Express application to invoke.
  *
  * @returns {Function} The `onRequest` hook.
  */
-export function createFallbackRunner(expressApp) {
+export function _createFallbackRunner(expressApp) {
   return function runExpressFallback(req, reply, next) {
     // only run Express when no Fastify route has been defined to handle the
     // request; otherwise let Fastify handle it

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ import Fastify from 'fastify';
 import {logger} from './logger.js';
 import morgan from 'morgan';
 import path from 'node:path';
-import {register as registerExpressAdapter} from './express-adapter.js';
+import {register as registerExpressAdapter} from './expressAdapter.js';
 const {config, util: {BedrockError}} = bedrock;
 
 // load config defaults
@@ -99,11 +99,6 @@ bedrock.events.on('bedrock.start', async () => {
       return server;
     }
   });
-
-  // backwards compatibility: `@fastify/express` used to decorate the fastify
-  // instance with an `express` property (an express app). Expose the root
-  // `app` here so external consumers that read `fastify.express` keep working.
-  _fastify.decorate('express', app);
 
   // if server is native http2...
   const isNativeHttp2 = server.constructor.name.startsWith('Http2');
@@ -527,7 +522,7 @@ function _addHttp2Support(app) {
           descriptors = {...descriptors, ...d};
         }
         // remove special case properties that the express adapter sets
-        // directly on `req.raw` (see `enhanceRequest`)
+        // directly on `req.raw` (see `expressifyRequest`)
         delete descriptors.hostname;
         delete descriptors.ip;
         delete descriptors.ips;

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,10 +24,10 @@ import errorHandler from 'errorhandler';
 import express from 'express';
 import expressSession from 'express-session';
 import Fastify from 'fastify';
-import fastifyExpress from '@fastify/express';
 import {logger} from './logger.js';
 import morgan from 'morgan';
 import path from 'node:path';
+import {register as registerExpressAdapter} from './express-adapter.js';
 const {config, util: {BedrockError}} = bedrock;
 
 // load config defaults
@@ -43,7 +43,7 @@ const _middleware = {};
 let _requestHandler;
 export {
   asyncHandler, express, Fastify, fastify, _middleware as middleware,
-  _requestHandler as requestHandler, _setFastify
+  _requestHandler as requestHandler, _getFastify, _setFastify
 };
 
 // create express application that bedrock modules will add routes to; a future
@@ -107,11 +107,11 @@ bedrock.events.on('bedrock.start', async () => {
     _addHttp2Support(app);
   }
 
-  // add hook that will run before the express compatibility hooks added by
-  // fastify-express below
+  // add hook that will run before the express adapter compatibility hooks
+  // registered below
   fastify.addHook('onRequest', function expressHttp2(req, reply, next) {
-    // add express APIs to req.raw/reply.raw
-    const {_http2, request, response} = fastify.express;
+    // add express APIs to req.raw/reply.raw using the root express `app`
+    const {_http2, request, response} = app;
     if(_http2) {
       // if http2 is used, augment response w/API from express.response; but
       // if http1 is used, just set prototype because augmentation creates
@@ -146,80 +146,6 @@ bedrock.events.on('bedrock.start', async () => {
 
     next();
   });
-
-  // capture express hooks added by `fastify-express` so they can be made
-  // conditional (based on whether any fastify routes take precedence)
-  const originalAddHook = fastify.addHook;
-  const capturedHooks = [];
-  fastify.addHook = function(...args) {
-    const [name, fn] = args;
-    if(name === 'captureHook') {
-      capturedHooks.push(fn);
-      return this;
-    }
-    return Reflect.apply(originalAddHook, this, args);
-  };
-  // ensure the express version used always matches the local version here
-  const originalDecorate = fastify.decorate;
-  fastify.decorate = function(...args) {
-    const [name] = args;
-    // always use local express version here instead
-    if(name === 'express') {
-      return Reflect.apply(originalDecorate, this, [name, express()]);
-    }
-    return Reflect.apply(originalDecorate, this, args);
-  };
-  await fastify.register(fastifyExpress, {expressHook: 'captureHook'});
-
-  // now register captured hooks, but only run them when there is no defined
-  // fastify route, ensuring express only runs as a fallback
-  for(const fn of capturedHooks) {
-    fastify.addHook('onRequest', function expressFallback(req, reply, next) {
-      // only run express as a fallback when no fastify route has been defined
-      // to handle the request
-      if(req.routeOptions.url === undefined) {
-        // restore original URL before final express processing; this is needed
-        // because fastify-express (v4.0.4) currently erroneously decodes `url`
-        if(fn === capturedHooks.at(-1)) {
-          req.raw.url = req.raw.originalUrl;
-          // express v4.0.6 adds a `headersSent` property to `reply.raw` that
-          // is set via `reply.raw.send()`, so that must also be overwritten
-          // as well via the new `reply.raw.send()` below
-          let replySent;
-          if(!reply.raw.headersSent) {
-            // must remove property erroneously added by fastify-express; the
-            // very presence of this property (even if set to false or
-            // undefined) can cause an application to abort
-            delete reply.raw.headersSent;
-          }
-          reply.raw.send = function send(...args) {
-            if(replySent) {
-              return;
-            }
-            replySent = true;
-            // only add the `headersSent` property now that `send()` was called
-            Object.defineProperty(reply.raw, 'headersSent', {
-              get() {
-                return replySent;
-              },
-              configurable: true,
-              enumerable: true
-            });
-            req.raw.url = req.raw.originalUrl;
-            return reply.send.apply(reply, args);
-          };
-        }
-        return Reflect.apply(fn, this, [req, reply, next]);
-      }
-      next();
-    });
-  }
-
-  // if server is native http2, add http2 support to fastify express app,
-  // otherwise (e.g., `spdy` is used) this is unnecessary
-  if(isNativeHttp2) {
-    _addHttp2Support(fastify.express);
-  }
 
   // init
   await bedrock.events.emit('bedrock-express.fastify.init', {fastify, app});
@@ -371,8 +297,13 @@ bedrock.events.on('bedrock.start', async () => {
     return;
   }
 
-  // add express app to fastify
-  fastify.use(app);
+  // register the express adapter; this adds the request compatibility hook and
+  // runs the express `app` as the fallback handler for any request that no
+  // fastify route claims (these hooks run after `expressHttp2` above); done
+  // here, after the ready check, to preserve the prior `fastify.use(app)`
+  // semantics where a canceled `bedrock-express.ready` prevents express from
+  // handling requests at all
+  registerExpressAdapter(fastify, {expressApp: app});
 
   // fastify ready check
   canceled = await bedrock.events.emit(
@@ -590,7 +521,8 @@ function _addHttp2Support(app) {
         for(const d of allDescriptors.reverse()) {
           descriptors = {...descriptors, ...d};
         }
-        // remove special case properties that will be set by fastify-express
+        // remove special case properties that the express adapter sets
+        // directly on `req.raw` (see `enhanceRequest`)
         delete descriptors.hostname;
         delete descriptors.ip;
         delete descriptors.ips;
@@ -698,4 +630,9 @@ function _allowLocalhostCors(req, res, next) {
 // For testing purposes only
 function _setFastify({fastify}) {
   _fastify = fastify;
+}
+
+// For testing purposes only
+function _getFastify() {
+  return _fastify;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,6 +100,11 @@ bedrock.events.on('bedrock.start', async () => {
     }
   });
 
+  // backwards compatibility: `@fastify/express` used to decorate the fastify
+  // instance with an `express` property (an express app). Expose the root
+  // `app` here so external consumers that read `fastify.express` keep working.
+  _fastify.decorate('express', app);
+
   // if server is native http2...
   const isNativeHttp2 = server.constructor.name.startsWith('Http2');
   if(isNativeHttp2) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bedrock/express",
-  "version": "8.6.8-0",
+  "version": "8.7.0",
   "type": "module",
   "description": "Bedrock express module",
   "license": "Apache-2.0",
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-express",
   "dependencies": {
-    "@fastify/express": "^4.0.6",
     "body-parser": "^1.20.4",
     "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bedrock/express",
-  "version": "8.7.0",
+  "version": "8.6.8-0",
   "type": "module",
   "description": "Bedrock express module",
   "license": "Apache-2.0",

--- a/test/mocha/02-fastify.js
+++ b/test/mocha/02-fastify.js
@@ -15,7 +15,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import {_getFastify, _setFastify, fastify} from '@bedrock/express';
+import {_getFastify, _setFastify, app, fastify} from '@bedrock/express';
+
+describe('fastify backwards-compat decorators', () => {
+  it('should expose the root express `app` as `fastify.express`', () => {
+    // `@fastify/express` historically decorated the fastify instance with an
+    // `express` property; preserve that surface so external consumers that
+    // read `fastify.express` continue to work after the adapter rewrite
+    fastify.express.should.equal(app);
+  });
+});
 
 describe('fastify', () => {
   let realFastify;

--- a/test/mocha/02-fastify.js
+++ b/test/mocha/02-fastify.js
@@ -15,12 +15,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import {_setFastify, fastify} from '@bedrock/express';
+import {_getFastify, _setFastify, fastify} from '@bedrock/express';
 
 describe('fastify', () => {
+  let realFastify;
   before(() => {
-    // Set fastify to null
+    // snapshot the real instance, then set fastify to null to exercise the
+    // proxy's not-ready error behavior
+    realFastify = _getFastify();
     _setFastify({fastify: null});
+  });
+  after(() => {
+    // restore the real instance so later test files are not affected
+    _setFastify({fastify: realFastify});
   });
   it('should throw error if fastify is null when getting prototype', () => {
     _assertInvalidStateError(() => {

--- a/test/mocha/03-express-adapter.js
+++ b/test/mocha/03-express-adapter.js
@@ -1,0 +1,94 @@
+/*!
+ * Copyright 2026 Digital Bazaar, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {agent} from '@bedrock/https-agent';
+import {httpClient} from '@digitalbazaar/http-client';
+
+const BASE_URL = 'https://localhost:18443';
+
+describe('express adapter', () => {
+  describe('URL handling', () => {
+    it('should preserve an encoded path parameter', async () => {
+      // `a%2Fb` must be delivered to express as the param value `a/b`; the
+      // adapter must NOT eagerly decode `req.url` (which would corrupt the
+      // path and split the segment)
+      let res;
+      let err;
+      try {
+        res = await httpClient.get(`${BASE_URL}/encoded-param/a%2Fb`, {agent});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(res);
+      res.status.should.equal(200);
+      res.data.id.should.equal('a/b');
+    });
+    it('should not decode the raw request url', async () => {
+      // `req.url` must remain encoded exactly as received; decoding it is the
+      // upstream bug that breaks encoded path params and enables the bogus
+      // "encoding bypass" reasoning
+      let res;
+      let err;
+      try {
+        res = await httpClient.get(
+          `${BASE_URL}/encoded-param/a%2Fb`, {agent});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(res);
+      res.data.url.should.include('a%2Fb');
+      res.data.url.should.not.include('a/b');
+    });
+    it('should preserve a double-encoded path parameter', async () => {
+      // double-encoding must not be silently collapsed; the app sees exactly
+      // what the client sent (`%252F` decodes once to the literal `%2F`)
+      let res;
+      let err;
+      try {
+        res = await httpClient.get(
+          `${BASE_URL}/encoded-param/a%252Fb`, {agent});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(res);
+      res.status.should.equal(200);
+      res.data.id.should.equal('a%2Fb');
+    });
+  });
+
+  describe('response behavior', () => {
+    it('should treat a second res.send() as a no-op', async () => {
+      // calling send() twice must not throw or corrupt the response; only the
+      // first body is returned
+      let res;
+      let err;
+      try {
+        res = await httpClient.get(`${BASE_URL}/double-send`, {agent});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(res);
+      res.status.should.equal(200);
+      res.data.order.should.equal('first');
+    });
+  });
+});

--- a/test/mocha/03-express-adapter.js
+++ b/test/mocha/03-express-adapter.js
@@ -72,6 +72,55 @@ describe('express adapter', () => {
       res.status.should.equal(200);
       res.data.id.should.equal('a%2Fb');
     });
+    it('should set `originalUrl` equal to the raw `url`', async () => {
+      // express sets `req.originalUrl = req.originalUrl || req.url` and does
+      // nothing else to `url`; the adapter must match that (no decode, no
+      // normalize), so the two are identical on a top-level route
+      let res;
+      let err;
+      try {
+        res = await httpClient.get(`${BASE_URL}/echo-url/a%2Fb`, {agent});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(res);
+      res.status.should.equal(200);
+      res.data.url.should.equal('/echo-url/a%2Fb');
+      res.data.originalUrl.should.equal('/echo-url/a%2Fb');
+    });
+    it('should NOT collapse duplicate slashes in the url', async () => {
+      // `@fastify/express` ran `normalizeUrl(..., {ignoreDuplicateSlashes})`,
+      // which express itself does NOT do. the adapter must leave duplicate
+      // slashes untouched, matching express.
+      let res;
+      let err;
+      try {
+        res = await httpClient.get(`${BASE_URL}/echo-url/a//b`, {agent});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(res);
+      res.status.should.equal(200);
+      res.data.url.should.equal('/echo-url/a//b');
+    });
+    it('should NOT treat a semicolon as a delimiter in the url', async () => {
+      // `@fastify/express` ran `normalizeUrl(..., {useSemicolonDelimiter})`,
+      // which express itself does NOT do. the adapter must leave the semicolon
+      // in the path untouched, matching express.
+      let res;
+      let err;
+      try {
+        res = await httpClient.get(`${BASE_URL}/echo-url/a;b/c`, {agent});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(res);
+      res.status.should.equal(200);
+      res.data.url.should.equal('/echo-url/a;b/c');
+    });
   });
 
   describe('response behavior', () => {

--- a/test/mocha/04-express-adapter-unit.js
+++ b/test/mocha/04-express-adapter-unit.js
@@ -19,11 +19,13 @@
 // unit tests for the express adapter's request-compat hook; these exercise the
 // hook logic directly with fake req/reply objects so the http2 `headersSent`
 // invariant (which the http1 integration suite cannot reach) is covered
-import {enhanceRequest} from '@bedrock/express/lib/express-adapter.js';
+import {
+  createFallbackRunner, enhanceRequest, register
+} from '@bedrock/express/lib/express-adapter.js';
 
 // builds a minimal fake fastify request/reply pair mirroring what fastify
 // passes to an onRequest hook
-function makeReqReply({url = '/foo/a%2Fb'} = {}) {
+function makeReqReply({url = '/foo/a%2Fb', body, cookies} = {}) {
   const req = {
     id: 'req-1',
     hostname: 'example.test',
@@ -31,6 +33,8 @@ function makeReqReply({url = '/foo/a%2Fb'} = {}) {
     ips: [],
     protocol: 'https',
     log: {},
+    body,
+    cookies,
     raw: {url, headers: {}}
   };
   const reply = {
@@ -94,5 +98,72 @@ describe('express adapter (unit)', () => {
     enhanceRequest(req, reply, () => {});
     reply.raw.send('a');
     reply.raw.headersSent.should.equal(true);
+  });
+
+  it('should copy req.body onto req.raw (body-parser compat)', () => {
+    const {req, reply} = makeReqReply({body: {a: 1}});
+    enhanceRequest(req, reply, () => {});
+    req.raw.body.should.deep.equal({a: 1});
+  });
+
+  it('should copy req.cookies onto req.raw (cookie-parser compat)', () => {
+    const {req, reply} = makeReqReply({cookies: {sid: 'x'}});
+    enhanceRequest(req, reply, () => {});
+    req.raw.cookies.should.deep.equal({sid: 'x'});
+  });
+});
+
+describe('express adapter (register)', () => {
+  it('should throw if `expressApp` is not a function', () => {
+    let err;
+    try {
+      register({addHook() {}}, {expressApp: {}});
+    } catch(e) {
+      err = e;
+    }
+    should.exist(err);
+    err.should.be.instanceof(TypeError);
+  });
+});
+
+describe('express adapter fallback runner (unit)', () => {
+  it('should defer to fastify when a route matched', () => {
+    let appCalled = false;
+    const run = createFallbackRunner(() => {
+      appCalled = true;
+    });
+    const req = {routeOptions: {url: '/matched'}, raw: {}};
+    const reply = {raw: {}, getHeaders() {
+      return {};
+    }};
+    let nextCalled = false;
+    run(req, reply, () => {
+      nextCalled = true;
+    });
+    nextCalled.should.equal(true);
+    appCalled.should.equal(false);
+  });
+
+  it('should copy fastify-set headers onto reply.raw then run express', () => {
+    let appCalled = false;
+    const run = createFallbackRunner((rawReq, rawRes, next) => {
+      appCalled = true;
+      next();
+    });
+    const setHeaders = {};
+    const req = {routeOptions: {url: undefined}, raw: {}};
+    const reply = {
+      raw: {
+        setHeader(name, value) {
+          setHeaders[name] = value;
+        }
+      },
+      getHeaders() {
+        return {'x-test': 'yes'};
+      }
+    };
+    run(req, reply, () => {});
+    appCalled.should.equal(true);
+    setHeaders['x-test'].should.equal('yes');
   });
 });

--- a/test/mocha/04-express-adapter-unit.js
+++ b/test/mocha/04-express-adapter-unit.js
@@ -1,0 +1,98 @@
+/*!
+ * Copyright 2026 Digital Bazaar, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// unit tests for the express adapter's request-compat hook; these exercise the
+// hook logic directly with fake req/reply objects so the http2 `headersSent`
+// invariant (which the http1 integration suite cannot reach) is covered
+import {enhanceRequest} from '@bedrock/express/lib/express-adapter.js';
+
+// builds a minimal fake fastify request/reply pair mirroring what fastify
+// passes to an onRequest hook
+function makeReqReply({url = '/foo/a%2Fb'} = {}) {
+  const req = {
+    id: 'req-1',
+    hostname: 'example.test',
+    ip: '127.0.0.1',
+    ips: [],
+    protocol: 'https',
+    log: {},
+    raw: {url, headers: {}}
+  };
+  const reply = {
+    raw: {
+      _headersSent: false,
+      end() {
+        this._headersSent = true;
+      }
+    },
+    send() {
+      this.raw.end();
+    }
+  };
+  return {req, reply};
+}
+
+describe('express adapter (unit)', () => {
+  it('should not define `headersSent` on reply.raw before send()', () => {
+    const {req, reply} = makeReqReply();
+    let nextCalled = false;
+    enhanceRequest(req, reply, () => {
+      nextCalled = true;
+    });
+    nextCalled.should.equal(true);
+    // the mere presence of this property aborts http2 writeHead callers; it
+    // must not exist until send() is invoked
+    const has = Object.prototype.hasOwnProperty.call(reply.raw, 'headersSent');
+    has.should.equal(false);
+  });
+
+  it('should leave req.raw.url untouched (no decode/normalize)', () => {
+    const {req, reply} = makeReqReply({url: '/foo/a%2Fb'});
+    enhanceRequest(req, reply, () => {});
+    req.raw.url.should.equal('/foo/a%2Fb');
+    req.raw.originalUrl.should.equal('/foo/a%2Fb');
+  });
+
+  it('should expose express-compat fields on req.raw', () => {
+    const {req, reply} = makeReqReply();
+    enhanceRequest(req, reply, () => {});
+    req.raw.id.should.equal('req-1');
+    req.raw.hostname.should.equal('example.test');
+    req.raw.ip.should.equal('127.0.0.1');
+    req.raw.protocol.should.equal('https');
+  });
+
+  it('should treat a second reply.raw.send() as a no-op', () => {
+    const {req, reply} = makeReqReply();
+    let sendCount = 0;
+    reply.send = function() {
+      sendCount++;
+    };
+    enhanceRequest(req, reply, () => {});
+    reply.raw.send('a');
+    reply.raw.send('b');
+    sendCount.should.equal(1);
+  });
+
+  it('should define `headersSent` only after send() is called', () => {
+    const {req, reply} = makeReqReply();
+    enhanceRequest(req, reply, () => {});
+    reply.raw.send('a');
+    reply.raw.headersSent.should.equal(true);
+  });
+});

--- a/test/mocha/04-express-adapter-unit.js
+++ b/test/mocha/04-express-adapter-unit.js
@@ -20,8 +20,8 @@
 // hook logic directly with fake req/reply objects so the http2 `headersSent`
 // invariant (which the http1 integration suite cannot reach) is covered
 import {
-  createFallbackRunner, enhanceRequest, register
-} from '@bedrock/express/lib/express-adapter.js';
+  _createFallbackRunner, expressifyRequest, register
+} from '@bedrock/express/lib/expressAdapter.js';
 
 // builds a minimal fake fastify request/reply pair mirroring what fastify
 // passes to an onRequest hook
@@ -55,7 +55,7 @@ describe('express adapter (unit)', () => {
   it('should not define `headersSent` on reply.raw before send()', () => {
     const {req, reply} = makeReqReply();
     let nextCalled = false;
-    enhanceRequest(req, reply, () => {
+    expressifyRequest(req, reply, () => {
       nextCalled = true;
     });
     nextCalled.should.equal(true);
@@ -67,14 +67,14 @@ describe('express adapter (unit)', () => {
 
   it('should leave req.raw.url untouched (no decode/normalize)', () => {
     const {req, reply} = makeReqReply({url: '/foo/a%2Fb'});
-    enhanceRequest(req, reply, () => {});
+    expressifyRequest(req, reply, () => {});
     req.raw.url.should.equal('/foo/a%2Fb');
     req.raw.originalUrl.should.equal('/foo/a%2Fb');
   });
 
   it('should expose express-compat fields on req.raw', () => {
     const {req, reply} = makeReqReply();
-    enhanceRequest(req, reply, () => {});
+    expressifyRequest(req, reply, () => {});
     req.raw.id.should.equal('req-1');
     req.raw.hostname.should.equal('example.test');
     req.raw.ip.should.equal('127.0.0.1');
@@ -87,7 +87,7 @@ describe('express adapter (unit)', () => {
     reply.send = function() {
       sendCount++;
     };
-    enhanceRequest(req, reply, () => {});
+    expressifyRequest(req, reply, () => {});
     reply.raw.send('a');
     reply.raw.send('b');
     sendCount.should.equal(1);
@@ -95,20 +95,20 @@ describe('express adapter (unit)', () => {
 
   it('should define `headersSent` only after send() is called', () => {
     const {req, reply} = makeReqReply();
-    enhanceRequest(req, reply, () => {});
+    expressifyRequest(req, reply, () => {});
     reply.raw.send('a');
     reply.raw.headersSent.should.equal(true);
   });
 
   it('should copy req.body onto req.raw (body-parser compat)', () => {
     const {req, reply} = makeReqReply({body: {a: 1}});
-    enhanceRequest(req, reply, () => {});
+    expressifyRequest(req, reply, () => {});
     req.raw.body.should.deep.equal({a: 1});
   });
 
   it('should copy req.cookies onto req.raw (cookie-parser compat)', () => {
     const {req, reply} = makeReqReply({cookies: {sid: 'x'}});
-    enhanceRequest(req, reply, () => {});
+    expressifyRequest(req, reply, () => {});
     req.raw.cookies.should.deep.equal({sid: 'x'});
   });
 });
@@ -129,7 +129,7 @@ describe('express adapter (register)', () => {
 describe('express adapter fallback runner (unit)', () => {
   it('should defer to fastify when a route matched', () => {
     let appCalled = false;
-    const run = createFallbackRunner(() => {
+    const run = _createFallbackRunner(() => {
       appCalled = true;
     });
     const req = {routeOptions: {url: '/matched'}, raw: {}};
@@ -146,7 +146,7 @@ describe('express adapter fallback runner (unit)', () => {
 
   it('should copy fastify-set headers onto reply.raw then run express', () => {
     let appCalled = false;
-    const run = createFallbackRunner((rawReq, rawRes, next) => {
+    const run = _createFallbackRunner((rawReq, rawRes, next) => {
       appCalled = true;
       next();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,12 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   app.get('/encoded-param/:id', asyncHandler(async (req, res) => {
     res.json({id: req.params.id, url: req.url, originalUrl: req.originalUrl});
   }));
+  // echoes the raw request url and originalUrl for any path beneath it so
+  // tests can verify the adapter does exactly what express itself does to
+  // `req.url`: no decode, no duplicate-slash collapse, no semicolon handling
+  app.get('/echo-url/*', asyncHandler(async (req, res) => {
+    res.json({url: req.url, originalUrl: req.originalUrl, path: req.path});
+  }));
   // sends twice; the second send must be a no-op (no throw, no duplicate
   // response)
   app.get('/double-send', asyncHandler(async (req, res) => {

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,17 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   app.get('/test', asyncHandler(async (req, res) => {
     res.json({success: true});
   }));
+  // echoes the route param and the raw request url so tests can verify that
+  // encoded path params are preserved and that `req.url` is not decoded
+  app.get('/encoded-param/:id', asyncHandler(async (req, res) => {
+    res.json({id: req.params.id, url: req.url, originalUrl: req.originalUrl});
+  }));
+  // sends twice; the second send must be a no-op (no throw, no duplicate
+  // response)
+  app.get('/double-send', asyncHandler(async (req, res) => {
+    res.json({order: 'first'});
+    res.json({order: 'second'});
+  }));
   // eslint-disable-next-line no-unused-vars
   app.get('/permission-denied-error', asyncHandler(async (req, res) => {
     throw new BedrockError('Permission denied.', 'PermissionDenied', {


### PR DESCRIPTION
## Summary

Removes the `@fastify/express` dependency and the reactive monkeypatching built around it, replacing both with a small in-repo adapter (`lib/express-adapter.js`).

The upstream plugin had two behaviors that fought Bedrock:
1. **Eager URL decoding** — it ran `decodeURI`/`normalizeUrl` on the request URL before express routing, corrupting encoded path parameters. Encoding is not a security boundary; we restored the original URL afterward.
2. **Unconditional `headersSent`** — it always defined a `headersSent` property on the raw response, whose mere presence aborts callers of the http2 `writeHead` (Node http2 compat layer, webpack hot middleware). We deleted/lazily-redefined it.

Working around both required intercepting `addHook`/`decorate`, capturing and replaying hooks, and re-implementing `send` — roughly as many lines as the plugin itself, and fragile against every upstream change. (See PR #79 for the most recent such patch.)

## What changed

- **New `lib/express-adapter.js`** — augments the raw req/res for express compatibility **without** touching the URL or eagerly defining `headersSent`, then runs the single root express `app` as the fallback handler when no fastify route matches.
- **`lib/index.js`** — removed ~65 lines of capture/decorate/replay hackery, the `fastify.use(app)` mount, and a duplicate http2 setup; `expressHttp2` now uses the one root `app` directly.
- **Removed the undocumented `fastify.use` method** — its only use was mounting `app` internally. Modules use the documented `bedrock-express.configure.*` event API.
- **`package.json`** — dropped `@fastify/express`; bumped to `8.7.0`.
- **Tests** — added integration (`03-express-adapter.js`) and unit (`04-express-adapter-unit.js`) regression tests for encoded path params, the `headersSent` invariant, and the double-send guard. Fixed a state leak in `02-fastify.js` (it nulled the fastify proxy without restoring it).
- **`.gitignore`** — ignore local tooling artifacts.

Spec: `docs/specs/fastify-express-adapter.md`.

## Testing

- `npm test` — 43 passing.
- `npm run lint` — clean.

## Reviewer notes / open questions

- **Version bump:** chose `8.7.0` (minor) since a dependency and an undocumented public method were removed. Confirm or adjust. CHANGELOG date is a placeholder (`2026-xx-xx`).
- **URL normalization:** the adapter passes the URL through untouched (no decode, no duplicate-slash/semicolon normalization). Do any DB apps rely on duplicate-slash collapsing?
- **`createProxyHandler`:** upstream supported a custom Proxy handler on `req.raw`. Assumed unused (only `bedrock-express` consumed the dep) — please confirm.
- **Hook ordering:** the adapter's hooks are registered after `expressHttp2`; verify that ordering is correct for the http2 path.

Per DB process this is a feature spec that should also go to Engineering / DevOps / CTO / Privacy Officer, and needs a second-engineer review.

Addresses #77. Supersedes the `headersSent` patch from #79.